### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ fixedbitset = "0.4.0"
 hashbrown = {version = "0.11.2", optional = true}
 log = "^0.4"
 num = "0.4.0"
-packed_simd = {version = "0.3.6", package = "packed_simd_2", optional = true}
+packed_simd = {version = "0.3.9", optional = true}
 rand = "0.8.4"
 rayon = "^1.5"
 serde = {version = "^1.0", features = ["derive"]}


### PR DESCRIPTION
packed_simd is now again being published under its original name.