### PR TITLE
Add possibility to dump and load from bytes

### DIFF
--- a/src/index/bruteforce_idx.rs
+++ b/src/index/bruteforce_idx.rs
@@ -84,9 +84,11 @@ impl<E: node::FloatElement, T: node::IdxType> ann_index::ANNIndex<E, T> for Brut
 impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwned>
     ann_index::SerializableIndex<E, T> for BruteForceIndex<E, T>
 {
-    fn load(path: &str) -> Result<Self, &'static str> {
-        let file = File::open(path).unwrap_or_else(|_| panic!("unable to open file {:?}", path));
-        let mut instance: BruteForceIndex<E, T> = bincode::deserialize_from(file).unwrap();
+    fn load_bytes(bytes: &[u8]) -> Result<Self, &'static str>
+    where
+        Self: Sized,
+    {
+        let mut instance: BruteForceIndex<E, T> = bincode::deserialize(bytes).unwrap();
         instance.nodes = instance
             .tmp_nodes
             .iter()
@@ -95,12 +97,9 @@ impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwn
         Ok(instance)
     }
 
-    fn dump(&mut self, path: &str) -> Result<(), &'static str> {
+    fn dump_bytes(&mut self) -> Result<Vec<u8>, &'static str> {
         self.tmp_nodes = self.nodes.iter().map(|x| *x.clone()).collect();
         let encoded_bytes = bincode::serialize(&self).unwrap();
-        let mut file = File::create(path).unwrap();
-        file.write_all(&encoded_bytes)
-            .unwrap_or_else(|_| panic!("unable to write file {:?}", path));
-        Result::Ok(())
+        Ok(encoded_bytes)
     }
 }

--- a/src/index/hnsw_idx.rs
+++ b/src/index/hnsw_idx.rs
@@ -15,7 +15,9 @@ use std::collections::BinaryHeap;
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fs;
 use std::fs::File;
+use std::io::Read;
 use std::io::Write;
 
 use std::sync::RwLock;
@@ -644,9 +646,11 @@ impl<E: node::FloatElement, T: node::IdxType> ann_index::ANNIndex<E, T> for HNSW
 impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwned>
     ann_index::SerializableIndex<E, T> for HNSWIndex<E, T>
 {
-    fn load(path: &str) -> Result<Self, &'static str> {
-        let file = File::open(path).unwrap_or_else(|_| panic!("unable to open file {:?}", path));
-        let mut instance: HNSWIndex<E, T> = bincode::deserialize_from(&file).unwrap();
+    fn load_bytes(bytes: &[u8]) -> Result<Self, &'static str>
+    where
+        Self: Sized,
+    {
+        let mut instance: HNSWIndex<E, T> = bincode::deserialize(bytes).unwrap();
         instance._nodes = instance
             ._nodes_tmp
             .iter()
@@ -685,7 +689,7 @@ impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwn
         Ok(instance)
     }
 
-    fn dump(&mut self, path: &str) -> Result<(), &'static str> {
+    fn dump_bytes(&mut self) -> Result<Vec<u8>, &'static str> {
         self._id2neighbor_tmp = Vec::with_capacity(self._id2neighbor.len());
         for i in 0..self._id2neighbor.len() {
             let mut tmp = Vec::with_capacity(self._id2neighbor[i].len());
@@ -712,9 +716,6 @@ impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwn
         }
 
         let encoded_bytes = bincode::serialize(&self).unwrap();
-        let mut file = File::create(path).unwrap();
-        file.write_all(&encoded_bytes)
-            .unwrap_or_else(|_| panic!("unable to write file {:?}", path));
-        Result::Ok(())
+        Ok(encoded_bytes)
     }
 }

--- a/src/index/pq_idx.rs
+++ b/src/index/pq_idx.rs
@@ -488,9 +488,8 @@ impl<E: node::FloatElement, T: node::IdxType> ann_index::ANNIndex<E, T> for IVFP
 impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwned>
     ann_index::SerializableIndex<E, T> for IVFPQIndex<E, T>
 {
-    fn load(path: &str) -> Result<Self, &'static str> {
-        let file = File::open(path).unwrap_or_else(|_| panic!("unable to open file {:?}", path));
-        let mut instance: IVFPQIndex<E, T> = bincode::deserialize_from(&file).unwrap();
+    fn load_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        let mut instance: IVFPQIndex<E, T> = bincode::deserialize(bytes).unwrap();
         instance._nodes = instance
             ._nodes_tmp
             .iter()
@@ -508,16 +507,13 @@ impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwn
         Ok(instance)
     }
 
-    fn dump(&mut self, path: &str) -> Result<(), &'static str> {
+    fn dump_bytes(&mut self) -> Result<Vec<u8>, &'static str> {
         self._nodes_tmp = self._nodes.iter().map(|x| *x.clone()).collect();
         for i in 0..self._n_kmeans_center {
             self._pq_list[i]._nodes_tmp =
                 self._pq_list[i]._nodes.iter().map(|x| *x.clone()).collect();
         }
         let encoded_bytes = bincode::serialize(&self).unwrap();
-        let mut file = File::create(path).unwrap();
-        file.write_all(&encoded_bytes)
-            .unwrap_or_else(|_| panic!("unable to write file {:?}", path));
-        Result::Ok(())
+        Ok(encoded_bytes)
     }
 }

--- a/src/index/ssg_idx.rs
+++ b/src/index/ssg_idx.rs
@@ -483,9 +483,8 @@ impl<E: node::FloatElement, T: node::IdxType> SSGIndex<E, T> {
 impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwned>
     ann_index::SerializableIndex<E, T> for SSGIndex<E, T>
 {
-    fn load(path: &str) -> Result<Self, &'static str> {
-        let file = File::open(path).unwrap_or_else(|_| panic!("unable to open file {:?}", path));
-        let mut instance: SSGIndex<E, T> = bincode::deserialize_from(&file).unwrap();
+    fn load_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        let mut instance: SSGIndex<E, T> = bincode::deserialize(bytes).unwrap();
         instance.nodes = instance
             .tmp_nodes
             .iter()
@@ -494,13 +493,10 @@ impl<E: node::FloatElement + DeserializeOwned, T: node::IdxType + DeserializeOwn
         Ok(instance)
     }
 
-    fn dump(&mut self, path: &str) -> Result<(), &'static str> {
+    fn dump_bytes(&mut self) -> Result<Vec<u8>, &'static str> {
         self.tmp_nodes = self.nodes.iter().map(|x| *x.clone()).collect();
         let encoded_bytes = bincode::serialize(&self).unwrap();
-        let mut file = File::create(path).unwrap();
-        file.write_all(&encoded_bytes)
-            .unwrap_or_else(|_| panic!("unable to write file {:?}", path));
-        Result::Ok(())
+        Ok(encoded_bytes)
     }
 }
 


### PR DESCRIPTION
This feature will allow to dump and load index from bytes array.
Currently it is possible to dump and load using std File. 
The change will help to use library eg. in WebAssembly envrionment.